### PR TITLE
Reinstate Image Width and Height Attributes

### DIFF
--- a/concrete/src/Html/Image.php
+++ b/concrete/src/Html/Image.php
@@ -67,14 +67,17 @@ class Image
             }
             $sources = [];
             $fallbackSrc = $f->getRelativePath();
+            // In the default Picture tag all sources share the same aspect ratio 
+            $width = $f->getAttribute('width');
+            $height = $f->getAttribute('height');
             if (!$fallbackSrc) {
                 $fallbackSrc = $f->getURL();
             }
-            foreach ($this->theme->getThemeResponsiveImageMap() as $thumbnail => $width) {
+            foreach ($this->theme->getThemeResponsiveImageMap() as $thumbnail => $breakpointWidth) {
                 $type = Type::getByHandle($thumbnail);
                 if ($type != null) {
                     $src = $f->getThumbnailURL($type->getBaseVersion());
-                    $sources[] = ['src' => $src, 'width' => $width];
+                    $sources[] = ['src' => $src, 'breakpointWidth' => $breakpointWidth, 'width' => $width, 'height' => $height];
                     if ($width == 0) {
                         $fallbackSrc = $src;
                     }

--- a/concrete/src/Html/Object/Picture.php
+++ b/concrete/src/Html/Object/Picture.php
@@ -91,6 +91,17 @@ class Picture extends Element
         foreach ($sources as $source) {
             $path = $source['src'];
             $width = $source['width'];
+
+            $height = 0;
+            if(isset($source['height'])) {
+                $height = $source['height'];
+            }
+
+            $breakpointWidth = 0;
+            if(isset($source['breakpointWidth'])) {
+                $breakpointWidth = $source['breakpointWidth'];
+            }
+
             $source = Source::create();
 
             if ($lazyLoadJavaScript) {
@@ -99,9 +110,13 @@ class Picture extends Element
                 $source->srcset($path);
             }
 
-            if ($width != 0) {
-                $source->media("(min-width: $width)");
+            if ($breakpointWidth != 0) {
+                $source->media("(min-width: $breakpointWidth)");
             }
+
+            $source->width($width);
+            $source->height($height);
+
             $this->setChild($source);
         }
 
@@ -133,6 +148,8 @@ class Picture extends Element
 
         $img = Image::create();
         $img->src($src);
+        $img->width(0);
+        $img->height(0);
 
         if ($lazyLoadNative) {
             $img->loading('lazy');

--- a/concrete/themes/atomik/blocks/image_slider/view.php
+++ b/concrete/themes/atomik/blocks/image_slider/view.php
@@ -75,6 +75,8 @@ $(document).ready(function(){
                 $f = File::getByID($row['fID']); ?>
                 <?php if (is_object($f)) {
                     $tag = Core::make('html/image', ['f' => $f])->getTag();
+                    $tag->setAttribute("width", $f->getAttribute('width'));
+                    $tag->setAttribute("height", $f->getAttribute('height'));
                     if ($row['title']) {
                         $tag->alt(h($row['title']));
                     } else {


### PR DESCRIPTION
When Responsive Web Design was introduced it became common practice to omit width and height attributes from image tags to allow images to scale dynamically.  Concrete CMS still follows this approach.

Modern browsers now use width and height attributes to set aspect ratio in order to reduce layout shift on load.  It has become best practice to include these attributes again and PageSpeed Insights will return a warning 'Image elements do not have explicit width and height' if they are not set.

https://web.dev/articles/optimize-cls?utm_source=lighthouse&utm_medium=lr#images-without-dimensions

This PR provides for width and height Attributes to be added to the img tag and to sources for responsive thumbnails in the Image block.

If this approach is acceptable we will create further pull requests to update other view files with image tag instances.
